### PR TITLE
Fix json_decode -> array

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -86,7 +86,7 @@ class Theme_Customizations_Cloner_Admin {
                         if(strlen($_FILES['themeMods']['tmp_name'])>0)
                         {
                             $mods=file_get_contents($_FILES['themeMods']['tmp_name']);
-                            $modArr=json_decode(sanitize_text_field($mods));
+                            $modArr=json_decode(sanitize_text_field($mods), true);
                             if(is_array($modArr))
                                 update_option('theme_mods_'.$import_theme,$modArr);
                             else


### PR DESCRIPTION
I was getting an error that "Theme modifications in uploaded file are not valid" during importing theme modifications. Turns out `json_decode` decodes the json into `stdClass` type and the check `is_array` on next line fails.
